### PR TITLE
Changed Telldus repo from stable to unstable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM homeassistant/home-assistant:latest
 LABEL maintainer="Timo Taskinen <timo.taskinen@iki.fi>"
 
 # Add Telldus repository
-RUN echo "deb-src http://download.telldus.com/debian/ stable main" >> /etc/apt/sources.list.d/telldus.list
+RUN echo "deb-src http://download.telldus.com/debian/ unstable main" >> /etc/apt/sources.list.d/telldus.list
 RUN curl -sSL http://download.telldus.com/debian/telldus-public.key | apt-key add -
 
 # Install dependencies. Compile and install telldusd


### PR DESCRIPTION
Docker image build fails when using the stable branch from Telldus.